### PR TITLE
Add missing requirements and point to generic X-Plane 11 location

### DIFF
--- a/config/xplane_config.yaml
+++ b/config/xplane_config.yaml
@@ -8,7 +8,7 @@ xplane_server:
   resolution_x: 600
   resolution_y: 600
   show_display: False
-  xplane_path: '/home/hemanth/X-Plane-11'
+  xplane_path: '~/X-Plane-11'
 
 ##------------------Experiment config------------------##
 experiment_config:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,11 @@ gym==0.17.3
 lxml==4.8.0
 matplotlib==3.5.1
 networkx==3.1
-numpy==1.21.5
+numpy
 osmnx==1.5.0
 psutil==5.9.0
 PyYAML==6.0
+scikit-learn
 scipy==1.11.1
 xplane_airports==4.0.1
 xplane_apt_convert==0.5.5


### PR DESCRIPTION
This PR makes a few minor changes to support running on other machines, including:
* Pointing to the generic X-Plane 11 location
* Updating `requirements.txt` (tested with `Python 3.10.12`). Note that `Python 3.8` cannot support the versions in this `requirements.txt` file.

Justification for the changes to the requirements:
![numpy-dep-issue](https://github.com/HemuManju/nasa-uli-xplane/assets/23203473/1b7264b7-b8b7-4c81-833f-28ba73fd7b21)
![scikit-learn-dep-need](https://github.com/HemuManju/nasa-uli-xplane/assets/23203473/9b83143a-8a58-4d6a-85df-79c3e5b82ddf)
